### PR TITLE
Update Raven appenders to log DEBUG to Console and WARN to Sentry.

### DIFF
--- a/raven-clojure-example/project.clj
+++ b/raven-clojure-example/project.clj
@@ -1,7 +1,7 @@
-(defproject raven-clojure-example "0.0.0-SNAPSHOT"
+(defproject raven-clojure-example "1.0-SNAPSHOT"
   :url "https://github.com/getsentry/raven-java-examples"
   :dependencies [
-    [org.clojure/clojure "1.7.0"]
+    [org.clojure/clojure "1.8.0"]
     [org.clojure/tools.logging "0.3.1"]
-    [com.getsentry.raven/raven-logback "7.3.0"]]
+    [com.getsentry.raven/raven-logback "7.8.1"]]
   :main raven-clojure-example.core)

--- a/raven-clojure-example/resources/logback.xml
+++ b/raven-clojure-example/resources/logback.xml
@@ -7,14 +7,15 @@
   </appender>
 
   <appender name="Sentry" class="com.getsentry.raven.logback.SentryAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>WARN</level>
+    </filter>
   </appender>
 
   <root level="debug">
     <appender-ref ref="console" />
-  </root>
-
-  <root level="warn">
     <appender-ref ref="Sentry"/>
   </root>
 
 </configuration>
+

--- a/raven-clojure-example/src/raven_clojure_example/core.clj
+++ b/raven-clojure-example/src/raven_clojure_example/core.clj
@@ -2,6 +2,9 @@
   (:require [clojure.tools.logging :as log]))
 
 (defn -main [& args]
+  (log/debug "Debug message")
+  (log/info "Info message")
+  (log/warn "Warn message")
   (try
     (println (/ 1 0))
     (catch Exception e

--- a/raven-grails3-example/build.gradle
+++ b/raven-grails3-example/build.gradle
@@ -41,7 +41,10 @@ dependencyManagement {
 }
 
 dependencies {
-    compile "com.getsentry.raven:raven-logback:7.3.0" // Sentry's (Raven) only dependency
+    compile "com.getsentry.raven:raven-logback:7.8.1"
+    compile "ch.qos.logback:logback-core:1.1.3"
+    compile "ch.qos.logback:logback-classic:1.1.3"
+
     compile "org.springframework.boot:spring-boot-starter-logging"
     compile "org.springframework.boot:spring-boot-autoconfigure"
     compile "org.grails:grails-core"

--- a/raven-grails3-example/grails-app/conf/logback.groovy
+++ b/raven-grails3-example/grails-app/conf/logback.groovy
@@ -1,3 +1,4 @@
+import ch.qos.logback.classic.filter.ThresholdFilter
 import com.getsentry.raven.logback.SentryAppender
 import grails.util.BuildSettings
 import grails.util.Environment
@@ -9,10 +10,14 @@ appender('STDOUT', ConsoleAppender) {
     }
 }
 
-root(ERROR, ['STDOUT'])
+// Register the Sentry appender
+appender('Sentry', SentryAppender) {
+    filter(ThresholdFilter) {
+        level = 'WARN'
+    }
+}
 
-appender('Sentry', SentryAppender) // Register the Sentry appender
-root(WARN, ['Sentry']) // Send WARN and above to Sentry
+root(DEBUG, ['STDOUT', 'Sentry'])
 
 def targetDir = BuildSettings.TARGET_DIR
 if (Environment.isDevelopmentMode() && targetDir) {

--- a/raven-grails3-example/grails-app/controllers/raven/grails/example/HelloController.groovy
+++ b/raven-grails3-example/grails-app/controllers/raven/grails/example/HelloController.groovy
@@ -8,6 +8,10 @@ class HelloController {
     Logger log = LoggerFactory.getLogger(getClass())
 
     def index() {
+        log.debug("Debug message")
+        log.info("Info message")
+        log.warn("Warn message")
+
         try {
             1 / 0
         } catch (Exception e) {

--- a/raven-java-log4j-example/pom.xml
+++ b/raven-java-log4j-example/pom.xml
@@ -12,8 +12,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <raven.version>7.3.0</raven.version>
-    <slf4j.version>1.7.19</slf4j.version>
+    <raven.version>7.8.1</raven.version>
+    <slf4j.version>1.7.22</slf4j.version>
   </properties>
 
   <dependencies>

--- a/raven-java-log4j-example/src/main/java/com/getsentry/example/Application.java
+++ b/raven-java-log4j-example/src/main/java/com/getsentry/example/Application.java
@@ -8,6 +8,10 @@ public class Application
 
     public static void main(String[] args)
     {
+        logger.debug("Debug message");
+        logger.info("Info message");
+        logger.warn("Warn message");
+
         try {
             int example = 1 / 0;
         } catch (Exception e) {

--- a/raven-java-log4j-example/src/main/resources/log4j.properties
+++ b/raven-java-log4j-example/src/main/resources/log4j.properties
@@ -5,3 +5,4 @@ log4j.appender.Console.layout=org.apache.log4j.PatternLayout
 log4j.appender.Console.layout.ConversionPattern=%d{HH:mm:ss.SSS} [%t] %-5p: %m%n
 
 log4j.appender.Sentry=com.getsentry.raven.log4j.SentryAppender
+log4j.appender.Sentry.threshold=WARN

--- a/raven-java-log4j2-example/pom.xml
+++ b/raven-java-log4j2-example/pom.xml
@@ -12,8 +12,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <raven.version>7.3.0</raven.version>
-    <slf4j.version>1.7.19</slf4j.version>
+    <raven.version>7.8.1</raven.version>
+    <slf4j.version>1.7.22</slf4j.version>
   </properties>
 
   <dependencies>

--- a/raven-java-log4j2-example/src/main/java/com/getsentry/example/Application.java
+++ b/raven-java-log4j2-example/src/main/java/com/getsentry/example/Application.java
@@ -9,6 +9,10 @@ public class Application
 
     public static void main(String[] args)
     {
+        logger.debug("Debug message");
+        logger.info("Info message");
+        logger.warn("Warn message");
+
         try {
             int example = 1 / 0;
         } catch (Exception e) {

--- a/raven-java-log4j2-example/src/main/resources/log4j2.xml
+++ b/raven-java-log4j2-example/src/main/resources/log4j2.xml
@@ -2,16 +2,16 @@
 <configuration status="warn" packages="org.apache.logging.log4j.core,com.getsentry.raven.log4j2">
 
     <appenders>
-        <Raven name="Sentry"/>
+        <Raven name="Sentry" />
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
         </Console>
     </appenders>
 
     <loggers>
-        <root level="all">
-            <appender-ref ref="Console"/>
-            <appender-ref ref="Sentry" level="warn"/>
+        <root level="ALL">
+            <appender-ref ref="Console" />
+            <appender-ref ref="Sentry" level="WARN" />
         </root>
     </loggers>
 

--- a/raven-java-log4j2-example/src/main/resources/log4j2.xml
+++ b/raven-java-log4j2-example/src/main/resources/log4j2.xml
@@ -2,7 +2,11 @@
 <configuration status="warn" packages="org.apache.logging.log4j.core,com.getsentry.raven.log4j2">
 
     <appenders>
-        <Raven name="Sentry"></Raven>
+        <Raven name="Sentry">
+            <Filters>
+                <ThresholdFilter level="WARN" onMatch="ACCEPT" />
+            </Filters>
+        </Raven>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>

--- a/raven-java-log4j2-example/src/main/resources/log4j2.xml
+++ b/raven-java-log4j2-example/src/main/resources/log4j2.xml
@@ -2,11 +2,7 @@
 <configuration status="warn" packages="org.apache.logging.log4j.core,com.getsentry.raven.log4j2">
 
     <appenders>
-        <Raven name="Sentry">
-            <Filters>
-                <ThresholdFilter level="WARN" onMatch="ACCEPT" />
-            </Filters>
-        </Raven>
+        <Raven name="Sentry"/>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
@@ -15,7 +11,7 @@
     <loggers>
         <root level="all">
             <appender-ref ref="Console"/>
-            <appender-ref ref="Sentry"/>
+            <appender-ref ref="Sentry" level="warn"/>
         </root>
     </loggers>
 

--- a/raven-java-logback-example/pom.xml
+++ b/raven-java-logback-example/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <raven.version>7.3.0</raven.version>
+    <raven.version>7.8.1</raven.version>
   </properties>
 
   <dependencies>

--- a/raven-java-logback-example/src/main/java/com/getsentry/example/Application.java
+++ b/raven-java-logback-example/src/main/java/com/getsentry/example/Application.java
@@ -9,6 +9,10 @@ public class Application
 
     public static void main(String[] args)
     {
+        logger.debug("Debug message");
+        logger.info("Info message");
+        logger.warn("Warn message");
+
         try {
             int example = 1 / 0;
         } catch (Exception e) {

--- a/raven-java-logback-example/src/main/resources/logback.xml
+++ b/raven-java-logback-example/src/main/resources/logback.xml
@@ -1,6 +1,6 @@
 <configuration>
 
-  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
@@ -12,8 +12,8 @@
     </filter>
   </appender>
 
-  <root level="debug">
-    <appender-ref ref="console" />
+  <root level="DEBUG">
+    <appender-ref ref="Console" />
     <appender-ref ref="Sentry"/>
   </root>
 

--- a/raven-java-logback-example/src/main/resources/logback.xml
+++ b/raven-java-logback-example/src/main/resources/logback.xml
@@ -7,13 +7,13 @@
   </appender>
 
   <appender name="Sentry" class="com.getsentry.raven.logback.SentryAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>WARN</level>
+    </filter>
   </appender>
 
   <root level="debug">
     <appender-ref ref="console" />
-  </root>
-
-  <root level="warn">
     <appender-ref ref="Sentry"/>
   </root>
 


### PR DESCRIPTION
While debugging another issue I realized our examples (and docs, PR to come) are often either incorrect (root logger configured multiple times) or just bad (Sentry set to send DEBUG/ALL messages).